### PR TITLE
Duplicate file descriptor closure in DQMFileSaverPB fix

### DIFF
--- a/DQMServices/FileIO/plugins/DQMFileSaverPB.cc
+++ b/DQMServices/FileIO/plugins/DQMFileSaverPB.cc
@@ -311,19 +311,16 @@ void DQMFileSaverPB::savePB(DQMStore* store, std::string const& filename, int ru
     GzipOutputStream gzip_stream(&file_stream, options);
     dqmstore_message.SerializeToZeroCopyStream(&gzip_stream);
 
-    // Flush the internal streams
+    // Flush the internal streams & Close the file descriptor
     gzip_stream.Close();
     file_stream.Close();
   } else {
     // We zlib compressed individual MEs so no need to compress the entire file again.
     dqmstore_message.SerializeToZeroCopyStream(&file_stream);
 
-    // Flush the internal stream
+    // Flush the internal stream & Close the file descriptor
     file_stream.Close();
   }
-
-  // Close the file descriptor
-  ::close(filedescriptor);
 
   // Maybe make some noise.
   edm::LogInfo("DQMFileSaverPB") << "savePB: successfully wrote " << nme << " objects  "


### PR DESCRIPTION
#### PR description:
From Srecko Morovic mail :
"We have been seeing rare issues with writing output files in HLT  with symptoms of the file sometimes being closed prematurely [1]. We saw similar issues in recent DAQ3 tests that used to happen when DQM File Saver is included (but was not investigated in detail at that time).
On inspecting the code, it turns out that in this module there is a protocol buffer file stream that is closed, and after that also the file descriptor [2] gets closed. In PB documentation [3] it's stated that the file is already closed by closing the PB stream, so the other close should not be necessary.
This could cause the race condition we're seeing, e.g. when in a multi-threaded setup some other thread opens the same file descriptor ID between two close calls. Maybe it also is the cause for other problems we have, such as frontier issues we see occasionally, which could be caused by socket fd close called prematurely.
In my private tests I see the empty output file problem disappearing when I remove line #326. Open fd count per process remains constant (so there is no fd leak introduced by this).
Conclusion from this is that line 326 should be removed. Please have a look and cross-check yourself.

[1] http://cmsonline.cern.ch/cms-elog/1127051
[2] https://github.com/cms-sw/cmssw/blob/master/DQMServices/FileIO/plugins/DQMFileSaverPB.cc#L326
[3] https://developers.google.com/protocol-buffers/docs/reference/cpp/google.protobuf.io.zero_copy_stream_impl#FileOutputStream.Close.details
"

#### PR validation:
TODO at p5 DQM playback with backport
